### PR TITLE
chore/replacing jcenter

### DIFF
--- a/flutter_google_places_sdk/example/android/build.gradle
+++ b/flutter_google_places_sdk/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/flutter_google_places_sdk_android/CHANGELOG.md
+++ b/flutter_google_places_sdk_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* replacing jcenter for mavinCentral
+
 ## 0.1.2+2
 
 * maxHeight in fetchPlacePhoto will now parsed correctly

--- a/flutter_google_places_sdk_android/CHANGELOG.md
+++ b/flutter_google_places_sdk_android/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.1.3
+## 0.1.2+3
 
-* replacing jcenter for mavinCentral
+* replacing jcenter for mavenCentral
 
 ## 0.1.2+2
 

--- a/flutter_google_places_sdk_android/android/build.gradle
+++ b/flutter_google_places_sdk_android/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.3.72'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/flutter_google_places_sdk_android/example/android/build.gradle
+++ b/flutter_google_places_sdk_android/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/flutter_google_places_sdk_android/pubspec.yaml
+++ b/flutter_google_places_sdk_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_android
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.1.3
+version: 0.1.2+3
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_android
 
 environment:

--- a/flutter_google_places_sdk_android/pubspec.yaml
+++ b/flutter_google_places_sdk_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_android
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.1.2+2
+version: 0.1.3
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_android
 
 environment:


### PR DESCRIPTION
Considering jcenter will shut down soon, it is suggested to replace jcenter repository for mavenCentral.
Flutter packages are already migrated to it > https://github.com/flutter/flutter/issues/82847