### PR TITLE
remove null-aware operation on non-null type

### DIFF
--- a/flutter_google_places_sdk_platform_interface/lib/method_channel_flutter_google_places_sdk.dart
+++ b/flutter_google_places_sdk_platform_interface/lib/method_channel_flutter_google_places_sdk.dart
@@ -95,7 +95,7 @@ class FlutterGooglePlacesSdkMethodChannel
       'fetchPlace',
       {
         'placeId': placeId,
-        'fields': fields?.map((e) => e.value).toList() ?? [],
+        'fields': fields.map((e) => e.value).toList() ?? [],
         'newSessionToken': newSessionToken,
       },
     ).then(_responseFromPlaceDetails);


### PR DESCRIPTION
The `fields` type is `List<PlaceField>`, and so the `?` is not needed. This avoids the error we see in our logs

```
../../.pub-cache/hosted/pub.dartlang.org/flutter_google_places_sdk_platform_interface-0.2.4+3/lib/method_channel_flutter_google_places_sdk.dart:98:19: Warning: Operand of null-aware operation '?.' has type 'List<PlaceField>' which excludes null.
 - 'List' is from 'dart:core'.
 - 'PlaceField' is from 'package:flutter_google_places_sdk_platform_interface/src/types/place_field.dart' ('../../.pub-cache/hosted/pub.dartlang.org/flutter_google_places_sdk_platform_interface-0.2.4+3/lib/src/types/place_field.dart').
        'fields': fields?.map((e) => e.value).toList() ?? [],
                  ^
```