### PR TITLE
[iOS] Implements latLngBoundsToMap

### DIFF
--- a/flutter_google_places_sdk/CHANGELOG.md
+++ b/flutter_google_places_sdk/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.3
+
+* Upgrades iOS to 0.1.3
+  * Fixes viewport always being null on iOS (#15)
+
 ## 0.3.2+7
 
 * Adding linux implementation.

--- a/flutter_google_places_sdk/pubspec.yaml
+++ b/flutter_google_places_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.3.2+7
+version: 0.3.3
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_google_places_sdk_platform_interface: ^0.2.4+3
-  flutter_google_places_sdk_ios: ^0.1.2+3
+  flutter_google_places_sdk_ios: ^0.1.3
   flutter_google_places_sdk_web: ^0.1.3+3
   flutter_google_places_sdk_android: ^0.1.2+5
   flutter_google_places_sdk_windows: ^0.1.0+1

--- a/flutter_google_places_sdk_ios/CHANGELOG.md
+++ b/flutter_google_places_sdk_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Implements latLngBoundsToMap
+
 ## 0.1.2+3
 
 * Updating platform interface to 0.2.4+3

--- a/flutter_google_places_sdk_ios/ios/Classes/SwiftFlutterGooglePlacesSdkIosPlugin.swift
+++ b/flutter_google_places_sdk_ios/ios/Classes/SwiftFlutterGooglePlacesSdkIosPlugin.swift
@@ -170,7 +170,7 @@ public class SwiftFlutterGooglePlacesSdkIosPlugin: NSObject, FlutterPlugin {
             "types": place.types?.map { (it) in return it.uppercased() },
             "userRatingsTotal": place.userRatingsTotal,
             "utcOffsetMinutes": place.utcOffsetMinutes,
-            // "viewport": latLngBoundsToMap(viewport: place.viewportInfo),
+            "viewport": latLngBoundsToMap(viewport: place.viewportInfo),
             "websiteUri": place.website?.absoluteString
         ]
     }
@@ -272,6 +272,16 @@ public class SwiftFlutterGooglePlacesSdkIosPlugin: NSObject, FlutterPlugin {
         return [
             "lat": coordinate.latitude,
             "lng": coordinate.longitude
+        ]
+    }
+
+    private func latLngBoundsToMap(viewport: GMSPlaceViewportInfo?) -> Dictionary<String, Any?>? {
+        guard let viewport = viewport else {
+            return nil
+        }
+        return [
+            "southwest": latLngToMap(coordinate: viewport.southWest),
+            "northeast": latLngToMap(coordinate: viewport.northEast)
         ]
     }
     

--- a/flutter_google_places_sdk_ios/pubspec.yaml
+++ b/flutter_google_places_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_ios
 description: The iOS implementation of Flutter plugin for google places sdk
-version: 0.1.2+3
+version: 0.1.3
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_ios
 
 environment:


### PR DESCRIPTION
Upgrades iOS package to 0.1.3
* Fixes viewport always being null on iOS by implementing latLngBoundsToMap method.


Fixes #15 