### PR TITLE
fix: session token usage in web sdk

### DIFF
--- a/flutter_google_places_sdk_web/CHANGELOG.md
+++ b/flutter_google_places_sdk_web/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.1.3+4
 
+* Fix session token usage
+
+## 0.1.3+4
+
 * Use formatted adrress instead of adr_address
 
 ## 0.1.3+3

--- a/flutter_google_places_sdk_web/CHANGELOG.md
+++ b/flutter_google_places_sdk_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.3+4
+## 0.1.3+5
 
 * Fix session token usage
 

--- a/flutter_google_places_sdk_web/lib/flutter_google_places_sdk_web.dart
+++ b/flutter_google_places_sdk_web/lib/flutter_google_places_sdk_web.dart
@@ -116,7 +116,13 @@ class FlutterGooglePlacesSdkWebPlugin extends FlutterGooglePlacesSdkPlatform {
       // https://issuetracker.google.com/issues/36219203
       log("locationRestriction is not supported: https://issuetracker.google.com/issues/36219203");
     }
+
+    final sessionToken = (newSessionToken ?? false) || _lastSessionToken == null
+        ? _lastSessionToken = AutocompleteSessionToken()
+        : _lastSessionToken;
+
     final prom = _svcAutoComplete!.getPlacePredictions(AutocompletionRequest()
+      ..sessionToken = sessionToken
       ..input = query
       ..origin = origin == null ? null : core.LatLng(origin.lat, origin.lng)
       ..types = typeFilterStr == null ? null : [typeFilterStr]
@@ -169,10 +175,13 @@ class FlutterGooglePlacesSdkWebPlugin extends FlutterGooglePlacesSdkPlatform {
     List<PlaceField>? fields,
     bool? newSessionToken,
   }) async {
+    final sessionToken = (newSessionToken ?? false) ? null : _lastSessionToken;
+    _lastSessionToken = null;
+
     final prom = _getDetails(PlaceDetailsRequest()
+      ..sessionToken = sessionToken
       ..placeId = placeId
       ..fields = fields?.map(this._mapField).toList(growable: false)
-      ..sessionToken = _lastSessionToken
       ..language = _language);
 
     final resp = await prom;

--- a/flutter_google_places_sdk_web/pubspec.yaml
+++ b/flutter_google_places_sdk_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_web
 description: The web implementation of Flutter plugin for google places sdk
-version: 0.1.3+4
+version: 0.1.3+5
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_web
 
 environment:


### PR DESCRIPTION
If I understand correctly, we should be keen to reuse a session token for all autocomplete calls and use it only once for "get place" call

https://developers.google.com/maps/documentation/places/web-service/session-tokens