### PR TITLE
Fix for typesFilter on findAutocompletePredictions

### DIFF
--- a/flutter_google_places_sdk/CHANGELOG.md
+++ b/flutter_google_places_sdk/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.3.7
+
+We now prepare the typesFilter for findAutocompletePredictions in the Dart side, so each client doesn't need to convert it to a string list.
+
+* Upgrading flutter_google_places_sdk_platform_interface to 0.2.7
+* Upgrading flutter_google_places_sdk_web to 0.1.6
+* Upgrading flutter_google_places_sdk_android to 0.1.8
+* Upgrading flutter_google_places_sdk_windows to 0.1.4
+* Upgrading flutter_google_places_sdk_linux to 0.1.4
+* Upgrading flutter_google_places_sdk_macos to 0.1.4
+
 ## 0.3.6
 
 * Exporting all types rather than just by name, allowing clients to also see the freezed classes

--- a/flutter_google_places_sdk/example/macos/Flutter/Flutter-Debug.xcconfig
+++ b/flutter_google_places_sdk/example/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/flutter_google_places_sdk/example/macos/Flutter/Flutter-Release.xcconfig
+++ b/flutter_google_places_sdk/example/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/flutter_google_places_sdk/example/macos/Podfile
+++ b/flutter_google_places_sdk/example/macos/Podfile
@@ -1,0 +1,43 @@
+platform :osx, '10.14'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/flutter_google_places_sdk/lib/flutter_google_places_sdk.dart
+++ b/flutter_google_places_sdk/lib/flutter_google_places_sdk.dart
@@ -100,7 +100,8 @@ class FlutterGooglePlacesSdk {
     return _addMethodCall(() => platform.findAutocompletePredictions(
           query,
           countries: countries,
-          placeTypesFilter: placeTypesFilter,
+          placeTypesFilter:
+              placeTypesFilter.map((type) => type.apiExpectedValue).toList(),
           newSessionToken: newSessionToken,
           origin: origin,
           locationBias: locationBias,

--- a/flutter_google_places_sdk/pubspec.yaml
+++ b/flutter_google_places_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.3.6
+version: 0.3.7
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk
 
 environment:
@@ -10,18 +10,35 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_google_places_sdk_platform_interface: ^0.2.6
-  flutter_google_places_sdk_ios: ^0.1.2+4
-  flutter_google_places_sdk_web: ^0.1.5
-  flutter_google_places_sdk_android: ^0.1.7
-  flutter_google_places_sdk_windows: ^0.1.3
-  flutter_google_places_sdk_linux: ^0.1.3
-  flutter_google_places_sdk_macos: ^0.1.3
+  flutter_google_places_sdk_platform_interface: ^0.2.7
+  flutter_google_places_sdk_ios: ^0.1.3
+  flutter_google_places_sdk_web: ^0.1.6
+  flutter_google_places_sdk_android: ^0.1.8
+  flutter_google_places_sdk_windows: ^0.1.4
+  flutter_google_places_sdk_linux: ^0.1.4
+  flutter_google_places_sdk_macos: ^0.1.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.4.2
+
+dependency_overrides:
+  flutter_google_places_sdk_platform_interface: 
+    path: ../flutter_google_places_sdk_platform_interface
+  flutter_google_places_sdk_ios:
+    path: ../flutter_google_places_sdk_ios
+  flutter_google_places_sdk_web:
+    path: ../flutter_google_places_sdk_web
+  flutter_google_places_sdk_android:
+    path: ../flutter_google_places_sdk_android
+  flutter_google_places_sdk_windows:
+    path: ../flutter_google_places_sdk_windows
+  flutter_google_places_sdk_linux:
+    path: ../flutter_google_places_sdk_linux
+  flutter_google_places_sdk_macos:
+    path: ../flutter_google_places_sdk_macos
+
 
 flutter:
   plugin:

--- a/flutter_google_places_sdk/test/flutter_google_places_sdk_test.dart
+++ b/flutter_google_places_sdk/test/flutter_google_places_sdk_test.dart
@@ -28,7 +28,24 @@ void main() {
     fullText: 'ftext6cad',
   );
 
-  const kPlace = const Place(latLng: LatLng(lat: 542.13, lng: -32.43), address: '', addressComponents: [], businessStatus: null, attributions: [], name: '', openingHours: null, phoneNumber: '', photoMetadatas: [], plusCode: null, priceLevel: null, rating: null, types: [], userRatingsTotal: null, utcOffsetMinutes: null, viewport: null, websiteUri: null);
+  const kPlace = const Place(
+      latLng: LatLng(lat: 542.13, lng: -32.43),
+      address: '',
+      addressComponents: [],
+      businessStatus: null,
+      attributions: [],
+      name: '',
+      openingHours: null,
+      phoneNumber: '',
+      photoMetadatas: [],
+      plusCode: null,
+      priceLevel: null,
+      rating: null,
+      types: [],
+      userRatingsTotal: null,
+      utcOffsetMinutes: null,
+      viewport: null,
+      websiteUri: null);
 
   final kDefaultResponses = <dynamic, dynamic>{
     'findAutocompletePredictions': <dynamic>[
@@ -114,7 +131,40 @@ void main() {
                 arguments: <String, dynamic>{
                   'query': queryTest,
                   'countries': countriesTest,
-                  "typeFilter": "ESTABLISHMENT",
+                  "typesFilter": ["establishment"],
+                  'newSessionToken': false,
+                  'origin': origin.toJson(),
+                  'locationBias': null,
+                  'locationRestriction': null,
+                }),
+          ],
+        );
+
+        final expected =
+            FindAutocompletePredictionsResponse([kPrediction1, kPrediction2]);
+        expect(result, equals(expected));
+      });
+      test('search with types filter cities', () async {
+        const queryTest = 'my-query-text';
+        const countriesTest = ['c5', 'c32'];
+        const placeTypeFilterTest = [PlaceTypeFilter.CITIES];
+        final origin = LatLng(lat: 32.51, lng: 95.31);
+        final result = await flutterGooglePlacesSdk.findAutocompletePredictions(
+            queryTest,
+            countries: countriesTest,
+            placeTypesFilter: placeTypeFilterTest,
+            newSessionToken: false,
+            origin: origin);
+
+        expect(
+          log,
+          <Matcher>[
+            _getInitializeMatcher(),
+            isMethodCall('findAutocompletePredictions',
+                arguments: <String, dynamic>{
+                  'query': queryTest,
+                  'countries': countriesTest,
+                  "typesFilter": ["(cities)"],
                   'newSessionToken': false,
                   'origin': origin.toJson(),
                   'locationBias': null,

--- a/flutter_google_places_sdk_android/CHANGELOG.md
+++ b/flutter_google_places_sdk_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.8
+
+* Now receiving an already converted string list for typesFilter in `findAutocompletePredictions`
+
 ## 0.1.7
 
 * Upgrading flutter_google_places_sdk_platform_interface to 0.2.6

--- a/flutter_google_places_sdk_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_google_places_sdk_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Sep 26 09:37:39 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip

--- a/flutter_google_places_sdk_android/android/src/main/kotlin/com/msh/flutter_google_places_sdk/FlutterGooglePlacesSdkPlugin.kt
+++ b/flutter_google_places_sdk_android/android/src/main/kotlin/com/msh/flutter_google_places_sdk/FlutterGooglePlacesSdkPlugin.kt
@@ -65,7 +65,7 @@ class FlutterGooglePlacesSdkPlugin : FlutterPlugin, MethodCallHandler {
             METHOD_FIND_AUTOCOMPLETE_PREDICTIONS -> {
                 val query = call.argument<String>("query")
                 val countries = call.argument<List<String>>("countries") ?: emptyList()
-                val placeTypesFilter = call.argument<List<String>>("typesFilter")?.map { it.lowercase() } ?: emptyList()
+                val placeTypesFilter = call.argument<List<String>>("typesFilter") ?: emptyList()
                 val newSessionToken = call.argument<Boolean>("newSessionToken")
 
                 val origin = latLngFromMap(call.argument<Map<String, Any?>>("origin"))

--- a/flutter_google_places_sdk_android/pubspec.yaml
+++ b/flutter_google_places_sdk_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_android
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.1.7
+version: 0.1.8
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_android
 
 environment:

--- a/flutter_google_places_sdk_http/CHANGELOG.md
+++ b/flutter_google_places_sdk_http/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+* Now receiving an already converted string list for typesFilter in `findAutocompletePredictions`
+
 ## 0.1.3
 
 * Upgrading flutter_google_places_sdk_platform_interface to 0.2.6

--- a/flutter_google_places_sdk_http/lib/flutter_google_places_sdk_http.dart
+++ b/flutter_google_places_sdk_http/lib/flutter_google_places_sdk_http.dart
@@ -50,7 +50,7 @@ class FlutterGooglePlacesSdkHttpPlugin
   Future<inter.FindAutocompletePredictionsResponse> findAutocompletePredictions(
     String query, {
     List<String>? countries,
-    List<inter.PlaceTypeFilter> placeTypesFilter = const [],
+    List<String> placeTypesFilter = const [],
     bool? newSessionToken,
     inter.LatLng? origin,
     inter.LatLngBounds? locationBias,
@@ -95,7 +95,7 @@ class FlutterGooglePlacesSdkHttpPlugin
   String _buildAutocompleteUrl(
     String query,
     List<String>? countries,
-    List<inter.PlaceTypeFilter> placeTypesFilter,
+    List<String> placeTypesFilter,
     String? sessionToken,
     inter.LatLng? origin,
     inter.LatLngBounds? locationBias,
@@ -118,7 +118,7 @@ class FlutterGooglePlacesSdkHttpPlugin
 
     // -- Place Type
     placeTypesFilter.forEach((placeType) {
-      url += '&types=${placeType.value.toLowerCase()}';
+      url += '&types=${placeType}';
     });
 
     // -- Session Token

--- a/flutter_google_places_sdk_http/pubspec.yaml
+++ b/flutter_google_places_sdk_http/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_http
 description: An http implementation of Flutter plugin to be used by other platform implementation
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_http
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   http: ^1.1.0
   latlong2: ^0.9.0
-  flutter_google_places_sdk_platform_interface: ^0.2.6
+  flutter_google_places_sdk_platform_interface: ^0.2.7
   freezed_annotation: ^2.3.2
   json_annotation: ^4.8.1
 

--- a/flutter_google_places_sdk_ios/CHANGELOG.md
+++ b/flutter_google_places_sdk_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Now receiving an already converted string list for typesFilter in `findAutocompletePredictions` instead of only one typeFilter enum object
+
 ## 0.1.2+4
 
 * Implements latLngBoundsToMap

--- a/flutter_google_places_sdk_ios/example/lib/main.dart
+++ b/flutter_google_places_sdk_ios/example/lib/main.dart
@@ -216,7 +216,7 @@ class _MyHomePageState extends State<MyHomePage> {
       final result = await _places.findAutocompletePredictions(
         _predictLastText!,
         countries: _countries,
-        placeTypeFilter: _placeTypeFilter,
+        placeTypesFilter: [_placeTypeFilter.apiExpectedValue],
         newSessionToken: false,
         origin: LatLng(lat: 43.12, lng: 95.20),
         locationBias: _locationBias,
@@ -253,7 +253,8 @@ class _MyHomePageState extends State<MyHomePage> {
     final theme = Theme.of(context);
     final errorText = err == null ? '' : err.toString();
     return Text(errorText,
-        style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.error));
+        style: theme.textTheme.bodySmall
+            ?.copyWith(color: theme.colorScheme.error));
   }
 
   List<Widget> _buildFetchPlaceWidgets() {

--- a/flutter_google_places_sdk_ios/ios/Classes/SwiftFlutterGooglePlacesSdkIosPlugin.swift
+++ b/flutter_google_places_sdk_ios/ios/Classes/SwiftFlutterGooglePlacesSdkIosPlugin.swift
@@ -40,7 +40,7 @@ public class SwiftFlutterGooglePlacesSdkIosPlugin: NSObject, FlutterPlugin {
             let args = call.arguments as! Dictionary<String,Any>
             let query = args["query"] as! String
             let countries = args["countries"] as? [String]? ?? [String]()
-            let placeTypeFilter = args["typeFilter"] as? String
+            let placeTypeFilters = args["typesFilter"] as? [String]
             let origin = latLngFromMap(argument: args["origin"] as? Dictionary<String, Any?>)
             let newSessionToken = args["newSessionToken"] as? Bool
             let locationBias = rectangularBoundsFromMap(argument: args["locationBias"] as? Dictionary<String, Any?>)
@@ -49,7 +49,7 @@ public class SwiftFlutterGooglePlacesSdkIosPlugin: NSObject, FlutterPlugin {
             
             // Create a type filter.
             let filter = GMSAutocompleteFilter()
-            filter.type = makeTypeFilter(typeFilter: placeTypeFilter);
+            filter.types = placeTypeFilters;
             filter.countries = countries
             filter.origin = origin
             filter.locationBias = locationBias
@@ -125,28 +125,6 @@ public class SwiftFlutterGooglePlacesSdkIosPlugin: NSObject, FlutterPlugin {
             }
         default:
             result(FlutterMethodNotImplemented)
-        }
-    }
-    
-    private func makeTypeFilter(typeFilter: String?) -> GMSPlacesAutocompleteTypeFilter {
-        guard let typeFilter = typeFilter else {
-            return GMSPlacesAutocompleteTypeFilter.noFilter
-        }
-        switch (typeFilter.uppercased()) {
-        case "ADDRESS":
-            return GMSPlacesAutocompleteTypeFilter.address
-        case "CITIES":
-            return GMSPlacesAutocompleteTypeFilter.city
-        case "ESTABLISHMENT":
-            return GMSPlacesAutocompleteTypeFilter.establishment
-        case "GEOCODE":
-            return GMSPlacesAutocompleteTypeFilter.geocode
-        case "REGIONS":
-            return GMSPlacesAutocompleteTypeFilter.region
-        case "ALL":
-            fallthrough
-        default:
-            return GMSPlacesAutocompleteTypeFilter.noFilter
         }
     }
     

--- a/flutter_google_places_sdk_ios/ios/flutter_google_places_sdk_ios.podspec
+++ b/flutter_google_places_sdk_ios/ios/flutter_google_places_sdk_ios.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '11.0'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
@@ -23,6 +23,6 @@ A new flutter plugin project.
   s.swift_version = '5.0'
 
   # Dependencies
-  s.dependency 'GooglePlaces'
+  s.dependency 'GooglePlaces', '~> 7.1.0'
   s.static_framework = true
 end

--- a/flutter_google_places_sdk_ios/pubspec.yaml
+++ b/flutter_google_places_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_ios
 description: The iOS implementation of Flutter plugin for google places sdk
-version: 0.1.2+4
+version: 0.1.3
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_ios
 
 environment:
@@ -10,8 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_google_places_sdk_platform_interface: # ^0.2.4+3
-    path: ../flutter_google_places_sdk_platform_interface
+  flutter_google_places_sdk_platform_interface: ^0.2.7
 
 dev_dependencies:
   flutter_test:

--- a/flutter_google_places_sdk_linux/CHANGELOG.md
+++ b/flutter_google_places_sdk_linux/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.4
+
+* Upgrading flutter_google_places_sdk_platform_interface to 0.2.7
+* Upgrading flutter_google_places_sdk_http to 0.1.4
+
 ## 0.1.3
 
 * Upgrading flutter_google_places_sdk_platform_interface to 0.2.6

--- a/flutter_google_places_sdk_linux/pubspec.yaml
+++ b/flutter_google_places_sdk_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_linux
 description: The linux implementation of Flutter plugin for google places sdk
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_linux
 
 environment:
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_google_places_sdk_platform_interface: ^0.2.6
-  flutter_google_places_sdk_http: ^0.1.3
+  flutter_google_places_sdk_platform_interface: ^0.2.7
+  flutter_google_places_sdk_http: ^0.1.4
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/flutter_google_places_sdk_macos/CHANGELOG.md
+++ b/flutter_google_places_sdk_macos/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.4
+
+* Upgrading flutter_google_places_sdk_platform_interface to 0.2.7
+* Upgrading flutter_google_places_sdk_http to 0.1.4
+
 ## 0.1.3
 
 * Upgrading flutter_google_places_sdk_platform_interface to 0.2.6

--- a/flutter_google_places_sdk_macos/pubspec.yaml
+++ b/flutter_google_places_sdk_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_macos
 description: The macos implementation of Flutter plugin for google places sdk
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_macos
 
 environment:
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_google_places_sdk_platform_interface: ^0.2.6
-  flutter_google_places_sdk_http: ^0.1.3
+  flutter_google_places_sdk_platform_interface: ^0.2.7
+  flutter_google_places_sdk_http: ^0.1.4
 
 dev_dependencies:
   flutter_lints: ^2.0.2

--- a/flutter_google_places_sdk_platform_interface/CHANGELOG.md
+++ b/flutter_google_places_sdk_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.7
+
+* Now receiving an already converted string list for typesFilter in `findAutocompletePredictions`
+* Added an `apiExpectedValue` computed property to convert `PlaceTypeFilter` enum value to the expected string for the Google API
+
 ## 0.2.6
 
 * Added any_map to all enums to freezed -> json_serializable

--- a/flutter_google_places_sdk_platform_interface/lib/flutter_google_places_sdk_platform.dart
+++ b/flutter_google_places_sdk_platform_interface/lib/flutter_google_places_sdk_platform.dart
@@ -79,7 +79,7 @@ abstract class FlutterGooglePlacesSdkPlatform extends PlatformInterface {
   Future<FindAutocompletePredictionsResponse> findAutocompletePredictions(
     String query, {
     List<String>? countries,
-    List<PlaceTypeFilter> placeTypesFilter = const [],
+    List<String> placeTypesFilter = const [],
     bool? newSessionToken,
     LatLng? origin,
     LatLngBounds? locationBias,

--- a/flutter_google_places_sdk_platform_interface/lib/method_channel_flutter_google_places_sdk.dart
+++ b/flutter_google_places_sdk_platform_interface/lib/method_channel_flutter_google_places_sdk.dart
@@ -51,7 +51,7 @@ class FlutterGooglePlacesSdkMethodChannel
   Future<FindAutocompletePredictionsResponse> findAutocompletePredictions(
     String query, {
     List<String>? countries,
-    List<PlaceTypeFilter> placeTypesFilter = const [],
+    List<String> placeTypesFilter = const [],
     bool? newSessionToken,
     LatLng? origin,
     LatLngBounds? locationBias,
@@ -65,7 +65,7 @@ class FlutterGooglePlacesSdkMethodChannel
       {
         'query': query,
         'countries': countries ?? [],
-        'typesFilter': placeTypesFilter.map((e) => e.value).toList(),
+        'typesFilter': placeTypesFilter,
         'newSessionToken': newSessionToken,
         'origin': origin?.toJson(),
         'locationBias': locationBias?.toJson(),

--- a/flutter_google_places_sdk_platform_interface/lib/src/types/place_type_filter.dart
+++ b/flutter_google_places_sdk_platform_interface/lib/src/types/place_type_filter.dart
@@ -28,8 +28,7 @@ enum PlaceTypeFilter {
   /// COUNTRY
   /// ADMINISTRATIVE_AREA_LEVEL_1
   /// ADMINISTRATIVE_AREA_LEVEL_2
-  REGIONS
-  ;
+  REGIONS;
 
   factory PlaceTypeFilter.fromJson(String name) {
     name = name.toLowerCase();
@@ -39,6 +38,21 @@ enum PlaceTypeFilter {
       }
     }
     throw ArgumentError.value(name, 'name', 'No enum value with that name');
+  }
+
+  String get apiExpectedValue {
+    switch (this) {
+      case PlaceTypeFilter.ADDRESS:
+        return 'address';
+      case PlaceTypeFilter.CITIES:
+        return '(cities)';
+      case PlaceTypeFilter.ESTABLISHMENT:
+        return 'establishment';
+      case PlaceTypeFilter.GEOCODE:
+        return 'geocode';
+      case PlaceTypeFilter.REGIONS:
+        return '(regions)';
+    }
   }
 }
 

--- a/flutter_google_places_sdk_platform_interface/pubspec.yaml
+++ b/flutter_google_places_sdk_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_platform_interface
 description: A common platform interface for accessing google maps native sdk on various platforms
-version: 0.2.6
+version: 0.2.7
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_platform_interface
 
 environment:

--- a/flutter_google_places_sdk_platform_interface/test/method_channel_flutter_google_places_sdk_test.dart
+++ b/flutter_google_places_sdk_platform_interface/test/method_channel_flutter_google_places_sdk_test.dart
@@ -67,6 +67,7 @@ void main() {
     test('findAutocompletePredictions', () async {
       const testQuery = 'my-test-query';
       const testCountries = ['c1', 'c2'];
+      const typesFilter = ['(cities)', 'country'];
       const newSessionToken = true;
       const origin = LatLng(lat: 325.21, lng: -952.52);
       const locationBias = LatLngBounds(
@@ -77,7 +78,7 @@ void main() {
           northeast: LatLng(lat: 38.64, lng: 23.32));
       await places.findAutocompletePredictions(testQuery,
           countries: testCountries,
-          placeTypesFilter: [PlaceTypeFilter.CITIES],
+          placeTypesFilter: typesFilter,
           newSessionToken: newSessionToken,
           origin: origin,
           locationBias: locationBias,
@@ -89,7 +90,7 @@ void main() {
               arguments: <String, Object>{
                 'query': testQuery,
                 'countries': testCountries,
-                'typesFilter': 'CITIES',
+                'typesFilter': typesFilter,
                 'newSessionToken': newSessionToken,
                 'origin': origin.toJson(),
                 'locationBias': locationBias.toJson(),

--- a/flutter_google_places_sdk_web/CHANGELOG.md
+++ b/flutter_google_places_sdk_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.6
+
+* Now receiving an already converted string list for typesFilter in `findAutocompletePredictions`, code we formerly used to convert was moved up to the shared interface (flutter_google_places_sdk_platform_interface)
+* Upgrading flutter_google_places_sdk_platform_interface to 0.2.7
+
 ## 0.1.5
 
 * Upgrading flutter_google_places_sdk_platform_interface to 0.2.6

--- a/flutter_google_places_sdk_web/lib/flutter_google_places_sdk_web.dart
+++ b/flutter_google_places_sdk_web/lib/flutter_google_places_sdk_web.dart
@@ -104,15 +104,13 @@ class FlutterGooglePlacesSdkWebPlugin extends FlutterGooglePlacesSdkPlatform {
   Future<FindAutocompletePredictionsResponse> findAutocompletePredictions(
     String query, {
     List<String>? countries,
-    List<PlaceTypeFilter> placeTypesFilter = const [],
+    List<String> placeTypesFilter = const [],
     bool? newSessionToken,
     inter.LatLng? origin,
     inter.LatLngBounds? locationBias,
     inter.LatLngBounds? locationRestriction,
   }) async {
     await _completer;
-    final typeFilterStr =
-        placeTypesFilter.map(_placeTypeToStr).toList(growable: false);
     if (locationRestriction != null) {
       // https://issuetracker.google.com/issues/36219203
       log("locationRestriction is not supported: https://issuetracker.google.com/issues/36219203");
@@ -120,7 +118,7 @@ class FlutterGooglePlacesSdkWebPlugin extends FlutterGooglePlacesSdkPlatform {
     final prom = _svcAutoComplete!.getPlacePredictions(AutocompletionRequest()
       ..input = query
       ..origin = origin == null ? null : core.LatLng(origin.lat, origin.lng)
-      ..types = typeFilterStr.isEmpty ? null : typeFilterStr
+      ..types = placeTypesFilter.isEmpty ? null : placeTypesFilter
       ..componentRestrictions = (ComponentRestrictions()..country = countries)
       ..bounds = _boundsToWeb(locationBias)
       ..language = _language);
@@ -132,21 +130,6 @@ class FlutterGooglePlacesSdkWebPlugin extends FlutterGooglePlacesSdkPlatform {
             .toList(growable: false) ??
         [];
     return FindAutocompletePredictionsResponse(predictions);
-  }
-
-  String? _placeTypeToStr(PlaceTypeFilter placeTypeFilter) {
-    switch (placeTypeFilter) {
-      case PlaceTypeFilter.ADDRESS:
-        return "address";
-      case PlaceTypeFilter.CITIES:
-        return "(cities)";
-      case PlaceTypeFilter.ESTABLISHMENT:
-        return "establishment";
-      case PlaceTypeFilter.GEOCODE:
-        return "geocode";
-      case PlaceTypeFilter.REGIONS:
-        return "(regions)";
-    }
   }
 
   inter.AutocompletePrediction _translatePrediction(

--- a/flutter_google_places_sdk_web/pubspec.yaml
+++ b/flutter_google_places_sdk_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_web
 description: The web implementation of Flutter plugin for google places sdk
-version: 0.1.5
+version: 0.1.6
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_web
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_google_places_sdk_platform_interface: ^0.2.6
+  flutter_google_places_sdk_platform_interface: ^0.2.7
   js: ^0.6.7
   google_maps: ^6.3.0
   collection: ^1.17.2 # Can't upgrade to 1.18 due to flutter sdk version

--- a/flutter_google_places_sdk_windows/CHANGELOG.md
+++ b/flutter_google_places_sdk_windows/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.4
+
+* Upgrading flutter_google_places_sdk_platform_interface to 0.2.7
+* Upgrading flutter_google_places_sdk_http to 0.1.4
+
 ## 0.1.3
 
 * Upgrading flutter_google_places_sdk_platform_interface to 0.2.6

--- a/flutter_google_places_sdk_windows/pubspec.yaml
+++ b/flutter_google_places_sdk_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_windows
 description: The windows implementation of Flutter plugin for google places sdk
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_windows
 
 environment:
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_google_places_sdk_platform_interface: ^0.2.6
-  flutter_google_places_sdk_http: ^0.1.3
+  flutter_google_places_sdk_platform_interface: ^0.2.7
+  flutter_google_places_sdk_http: ^0.1.4
 
 dev_dependencies:
   flutter_lints: ^2.0.2


### PR DESCRIPTION
Google changed the typesFilter options to receive a list of strings instead of a single enum value. They are really picky about the expected strings filter received. This patch should fix the implementation for the Android, iOS, http and web platforms.

Bugs related :
https://github.com/matanshukry/flutter_google_places_sdk/issues/55 https://github.com/matanshukry/flutter_google_places_sdk/issues/48 https://github.com/matanshukry/flutter_google_places_sdk/issues/57