### PR TITLE
Update GooglePlaces POD to 8.3.0 latest version

### DIFF
--- a/flutter_google_places_sdk_ios/ios/flutter_google_places_sdk_ios.podspec
+++ b/flutter_google_places_sdk_ios/ios/flutter_google_places_sdk_ios.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_google_places_sdk_ios'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '13.0'
+  s.platform = :ios, '15.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
@@ -23,6 +23,6 @@ A new flutter plugin project.
   s.swift_version = '5.0'
 
   # Dependencies
-  s.dependency 'GooglePlaces', '~> 7.1.0'
+  s.dependency 'GooglePlaces', '~> 8.3.0'
   s.static_framework = true
 end

--- a/flutter_google_places_sdk_ios/pubspec.yaml
+++ b/flutter_google_places_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_ios
 description: The iOS implementation of Flutter plugin for google places sdk
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_ios
 
 environment:


### PR DESCRIPTION
While trying to build on an Apple Silicon Macbook to an iOS emulator, I got the following error:
```Error (Xcode): Building for 'iOS-simulator', but linking in object file (/app-path/ios/Pods/GooglePlaces/Frameworks/GooglePlaces.framework/GooglePlaces) built for 'iOS'```

I have examined and seen that GooglePlaces is outdated, so I upgraded it from 7.1.0 to 8.3.0.
There is no breaking change in that upgrade except for the iOS minimum version is 15.0 in this version.

The upgrade solved the build error.

This PR solves issue https://github.com/matanshukry/flutter_google_places_sdk/issues/17. 
