### PR TITLE
Upgrade to GooglePlaces 8.5.0 and  google_maps 7.1.0

### DIFF
--- a/flutter_google_places_sdk_ios/ios/flutter_google_places_sdk_ios.podspec
+++ b/flutter_google_places_sdk_ios/ios/flutter_google_places_sdk_ios.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_google_places_sdk_ios'
-  s.version          = '0.0.2'
+  s.version          = '0.0.3'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '15.0'
+  s.platform = :ios, '14.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
@@ -23,6 +23,6 @@ A new flutter plugin project.
   s.swift_version = '5.0'
 
   # Dependencies
-  s.dependency 'GooglePlaces', '~> 8.3.0'
+  s.dependency 'GooglePlaces', '~> 8.5.0'
   s.static_framework = true
 end

--- a/flutter_google_places_sdk_web/pubspec.yaml
+++ b/flutter_google_places_sdk_web/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_google_places_sdk_platform_interface: ^0.2.7
   js: ^0.6.7
-  google_maps: ^6.3.0
+  google_maps: ^7.1.0
   collection: ^1.17.2 # Can't upgrade to 1.18 due to flutter sdk version
 
 dev_dependencies:


### PR DESCRIPTION
Google Places works on ios 14 without problem. ios was downgraded from 15 to 14 introduced in commit 85ad330. GooglePlaces was upgraded from 8.3.0 to 8.5.0. Because of a dependency was necessary to upgraded google_maps on web to 7.1.0. This fix #75 