### PR TITLE
Upgrade to AGP 8.2.2 and Kotlin to 1.9.22

### DIFF
--- a/flutter_google_places_sdk_android/android/build.gradle
+++ b/flutter_google_places_sdk_android/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.msh.flutter_google_places_sdk'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.22'
+    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,15 +25,16 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    // Conditional for compatibility with AGP <4.2.
-    if (project.android.hasProperty("namespace")) {
-        namespace 'com.msh.flutter_google_places_sdk'
-    }
-    compileSdkVersion 30
+    namespace 'com.msh.flutter_google_places_sdk_example'
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 
     sourceSets {
@@ -41,7 +42,7 @@ android {
         test.java.srcDirs += 'src/test/kotlin'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/flutter_google_places_sdk_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_google_places_sdk_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip

--- a/flutter_google_places_sdk_android/android/src/main/AndroidManifest.xml
+++ b/flutter_google_places_sdk_android/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.msh.flutter_google_places_sdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/flutter_google_places_sdk_android/pubspec.yaml
+++ b/flutter_google_places_sdk_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_android
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.1.8
+version: 0.1.9
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_android
 
 environment:


### PR DESCRIPTION
This pull request fixes issue #71. In newer versions of Flutter, it is necessary to add the following to the android/build.gradle file:

```
kotlinOptions {
    jvmTarget = '1.8'
}
```
Additionally, the Android Gradle Plugin (AGP) has been upgraded to version 8.2.2, and Kotlin has been updated to version 1.9.22. The minSdk version is now 21, and the target SDK version is 34. There is another pull request, #82, which is similar but also upgrades Java and requires API level 23 and higher. For that reason I made a new pull request with minSdk on 21