### PR TITLE
Fix warning `Google Maps JavaScript API has been loaded directly without loading=async`

### DIFF
--- a/flutter_google_places_sdk_web/lib/flutter_google_places_sdk_web.dart
+++ b/flutter_google_places_sdk_web/lib/flutter_google_places_sdk_web.dart
@@ -68,7 +68,7 @@ class FlutterGooglePlacesSdkWebPlugin extends FlutterGooglePlacesSdkPlatform {
     } else {
       final body = html.window.document.querySelector('body')!;
       var src =
-          'https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&callback=initMap';
+          'https://maps.googleapis.com/maps/api/js?key=${apiKey}&loading=async&libraries=places&callback=initMap';
       if (locale?.languageCode != null) {
         _language = locale?.languageCode;
       }


### PR DESCRIPTION
As suggested by [documentation](https://developers.google.com/maps/documentation/javascript/load-maps-js-api#add_a_script_tag) added `loading=async` parameter in request.
This helps to avoid Warning message in browser console:
```
Google Maps JavaScript API has been loaded directly without loading=async. This can result in suboptimal performance. For best-practice loading patterns please see https://goo.gle/js-api-loading
```