### PR TITLE
fix: add region code to fetchPlace API

### DIFF
--- a/flutter_google_places_sdk_platform_interface/CHANGELOG.md
+++ b/flutter_google_places_sdk_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* fix: Add missing argument `regionCode` to `fetchPlace` function
+
 ## 0.3.0
 
 * feat: Added support for Google Places (new) which can be enabled through `initialize` function.

--- a/flutter_google_places_sdk_platform_interface/lib/flutter_google_places_sdk_platform.dart
+++ b/flutter_google_places_sdk_platform_interface/lib/flutter_google_places_sdk_platform.dart
@@ -100,6 +100,7 @@ abstract class FlutterGooglePlacesSdkPlatform extends PlatformInterface {
     String placeId, {
     required List<PlaceField> fields,
     bool? newSessionToken,
+    String? regionCode,
   }) {
     throw UnimplementedError('fetchPlaceDetails() has not been implemented.');
   }

--- a/flutter_google_places_sdk_platform_interface/lib/method_channel_flutter_google_places_sdk.dart
+++ b/flutter_google_places_sdk_platform_interface/lib/method_channel_flutter_google_places_sdk.dart
@@ -96,6 +96,7 @@ class FlutterGooglePlacesSdkMethodChannel
     String placeId, {
     required List<PlaceField> fields,
     bool? newSessionToken,
+    String? regionCode,
   }) {
     return _channel.invokeMapMethod(
       'fetchPlace',
@@ -103,6 +104,7 @@ class FlutterGooglePlacesSdkMethodChannel
         'placeId': placeId,
         'fields': fields.map((e) => e.value).toList(),
         'newSessionToken': newSessionToken,
+        'regionCode': regionCode,
       },
     ).then(_responseFromPlaceDetails);
   }

--- a/flutter_google_places_sdk_platform_interface/pubspec.yaml
+++ b/flutter_google_places_sdk_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_platform_interface
 description: A common platform interface for accessing google maps native sdk on various platforms
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_platform_interface
 
 environment:

--- a/flutter_google_places_sdk_platform_interface/test/method_channel_flutter_google_places_sdk_test.dart
+++ b/flutter_google_places_sdk_platform_interface/test/method_channel_flutter_google_places_sdk_test.dart
@@ -109,6 +109,7 @@ void main() {
         placeId,
         fields: testFields,
         newSessionToken: newSessionToken,
+        regionCode: 'us',
       );
       expect(
         log,
@@ -117,6 +118,7 @@ void main() {
             'placeId': placeId,
             'fields': testFields.map((e) => e.value).toList(growable: false),
             'newSessionToken': newSessionToken,
+            'regionCode': 'us',
           })
         ],
       );


### PR DESCRIPTION
This parameter is used in the [FetchPlaceRequest](https://developers.google.com/maps/documentation/places/android-sdk/reference/com/google/android/libraries/places/api/net/FetchPlaceRequest.Builder#setRegionCode(java.lang.String)) class, added in SDK v3.5 on Android.