### PR TITLE
[iOS] Add autocomplete place types support 

### DIFF
--- a/flutter_google_places_sdk_ios/CHANGELOG.md
+++ b/flutter_google_places_sdk_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6
+
+* Add 'placeTypes' property in 'GMSAutocompletePrediction'
+
 ## 0.1.5
 
 * Upgrade to Google Places 8.5.0 and Google Maps 7.1.0 

--- a/flutter_google_places_sdk_ios/ios/Classes/SwiftFlutterGooglePlacesSdkIosPlugin.swift
+++ b/flutter_google_places_sdk_ios/ios/Classes/SwiftFlutterGooglePlacesSdkIosPlugin.swift
@@ -311,6 +311,7 @@ public class SwiftFlutterGooglePlacesSdkIosPlugin: NSObject, FlutterPlugin {
             "primaryText": prediction.attributedPrimaryText.string,
             "secondaryText": prediction.attributedSecondaryText?.string ?? "",
             "fullText": prediction.attributedFullText.string
+            "placeTypes": prediction.types.map { (it) in return it.uppercased() }
         ];
     }
 

--- a/flutter_google_places_sdk_ios/pubspec.yaml
+++ b/flutter_google_places_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places_sdk_ios
 description: The iOS implementation of Flutter plugin for google places sdk
-version: 0.1.5
+version: 0.1.6
 homepage: https://github.com/matanshukry/flutter_google_places_sdk/tree/master/flutter_google_places_sdk_ios
 
 environment:


### PR DESCRIPTION
## Change log

1. Added support for '[Place types](https://developers.google.com/maps/documentation/places/web-service/supported_types)' in iOS packages.
2. Upgraded iOS package version (0.1.6).
3. Updated the CHANGELOG.

## How to test 

### Sample code
```
final result = await places_sdk.FlutterGooglePlacesSdk(
      googleMapsApiKey,
      locale: sampleLocale,
    ).findAutocompletePredictions(
      input,
      countries: [countryCode],
      newSessionToken: newSessionToken,
      origin: originLocation,
    );

    final placeTypes = result.predictions
        .map((predictions) => predictions.placeTypes)
        .toList();
```

### iOS sample
<img width="825" alt="Screenshot 2025-02-15 at 15 12 21" src="https://github.com/user-attachments/assets/d9a84b20-14ce-4cdb-821b-5345625746f0" />
